### PR TITLE
Implement two-cookie capabilities pattern

### DIFF
--- a/apps/web/src/api/middleware/auth.ts
+++ b/apps/web/src/api/middleware/auth.ts
@@ -1,6 +1,15 @@
 import { createMiddleware } from "hono/factory";
 import { createAuth } from "../auth";
 import type { HonoEnv } from "../types";
+import {
+  type Capabilities,
+  createSignedCapabilities,
+  readCapabilities,
+  setCapabilitiesCookie,
+} from "../../lib/capabilities";
+import { createDb } from "../../db/client";
+import { member } from "../../db/schema/auth";
+import { eq, and } from "drizzle-orm";
 
 export const loadSession = createMiddleware<HonoEnv>(async (c, next) => {
   const auth = createAuth(c.env);
@@ -21,9 +30,45 @@ export const loadSession = createMiddleware<HonoEnv>(async (c, next) => {
     };
     c.set("user", data.user);
     c.set("session", data.session);
+
+    // Try reading capabilities from cookie first (avoids D1 query)
+    const existing = await readCapabilities(c.req.header("cookie"), c.env.BETTER_AUTH_SECRET);
+
+    if (existing && existing.userId === data.user.id) {
+      c.set("capabilities", existing);
+    } else {
+      // Build capabilities from D1 and set cookie for next request
+      const userId = data.user.id as string;
+      const activeOrgId = (data.session.activeOrganizationId as string) ?? null;
+      const isAdmin = (data.user.role as string) === "admin";
+
+      let orgRole: string | null = null;
+      if (activeOrgId) {
+        const db = createDb(c.env.DB);
+        const membership = await db
+          .select({ role: member.role })
+          .from(member)
+          .where(and(eq(member.userId, userId), eq(member.organizationId, activeOrgId)))
+          .get();
+        orgRole = membership?.role ?? null;
+      }
+
+      const capabilities: Capabilities = {
+        userId,
+        orgId: activeOrgId,
+        role: orgRole,
+        isAdmin,
+        iat: Date.now(),
+      };
+
+      const signed = await createSignedCapabilities(capabilities, c.env.BETTER_AUTH_SECRET);
+      setCapabilitiesCookie(c.res.headers, signed);
+      c.set("capabilities", capabilities);
+    }
   } else {
     c.set("user", null);
     c.set("session", null);
+    c.set("capabilities", null);
   }
 
   await next();
@@ -32,6 +77,29 @@ export const loadSession = createMiddleware<HonoEnv>(async (c, next) => {
 export const requireAuth = createMiddleware<HonoEnv>(async (c, next) => {
   if (!c.var.user) {
     return c.json({ error: "Unauthorized" }, 401);
+  }
+  await next();
+});
+
+export const requireOrgMember = createMiddleware<HonoEnv>(async (c, next) => {
+  if (!c.var.capabilities?.orgId) {
+    return c.json({ error: "No active organization" }, 403);
+  }
+  await next();
+});
+
+export const requireOrgRole = (...roles: string[]) =>
+  createMiddleware<HonoEnv>(async (c, next) => {
+    const cap = c.var.capabilities;
+    if (!cap?.role || !roles.includes(cap.role)) {
+      return c.json({ error: "Insufficient permissions" }, 403);
+    }
+    await next();
+  });
+
+export const requireAdmin = createMiddleware<HonoEnv>(async (c, next) => {
+  if (!c.var.capabilities?.isAdmin) {
+    return c.json({ error: "Admin access required" }, 403);
   }
   await next();
 });

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -1,3 +1,4 @@
+import type { Capabilities } from "../lib/capabilities";
 import type { Logger } from "../lib/logging/logger";
 
 export type HonoEnv = {
@@ -5,6 +6,7 @@ export type HonoEnv = {
   Variables: {
     user: Record<string, unknown> | null;
     session: Record<string, unknown> | null;
+    capabilities: Capabilities | null;
     logger: Logger;
   };
 };

--- a/apps/web/src/lib/capabilities.ts
+++ b/apps/web/src/lib/capabilities.ts
@@ -1,0 +1,102 @@
+import { z } from "zod";
+
+export const capabilitiesSchema = z.object({
+  userId: z.string(),
+  orgId: z.string().nullable(),
+  role: z.string().nullable(),
+  isAdmin: z.boolean(),
+  iat: z.number(),
+});
+
+export type Capabilities = z.infer<typeof capabilitiesSchema>;
+
+const COOKIE_NAME = "rafters_cap";
+const MAX_AGE = 300; // 5 minutes, matches session cookieCache
+
+function encodePayload(payload: Capabilities): string {
+  return btoa(JSON.stringify(payload));
+}
+
+function decodePayload(encoded: string): Capabilities | null {
+  try {
+    const json = JSON.parse(atob(encoded));
+    return capabilitiesSchema.parse(json);
+  } catch {
+    return null;
+  }
+}
+
+async function sign(payload: string, secret: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, new TextEncoder().encode(payload));
+  const sigHex = [...new Uint8Array(signature)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `${payload}.${sigHex}`;
+}
+
+async function verify(cookie: string, secret: string): Promise<Capabilities | null> {
+  const lastDot = cookie.lastIndexOf(".");
+  if (lastDot === -1) return null;
+
+  const payload = cookie.slice(0, lastDot);
+  const sigHex = cookie.slice(lastDot + 1);
+
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["verify"],
+  );
+
+  const sigBytes = new Uint8Array(sigHex.match(/.{2}/g)?.map((h) => Number.parseInt(h, 16)) ?? []);
+  const valid = await crypto.subtle.verify(
+    "HMAC",
+    key,
+    sigBytes,
+    new TextEncoder().encode(payload),
+  );
+  if (!valid) return null;
+
+  const capabilities = decodePayload(payload);
+  if (!capabilities) return null;
+
+  const age = Date.now() - capabilities.iat;
+  if (age > MAX_AGE * 1000) return null;
+
+  return capabilities;
+}
+
+export function setCapabilitiesCookie(headers: Headers, signedValue: string): void {
+  headers.append(
+    "set-cookie",
+    `${COOKIE_NAME}=${signedValue}; Path=/; HttpOnly; Secure; SameSite=Lax; Max-Age=${MAX_AGE}`,
+  );
+}
+
+export async function createSignedCapabilities(
+  capabilities: Capabilities,
+  secret: string,
+): Promise<string> {
+  const payload = encodePayload(capabilities);
+  return sign(payload, secret);
+}
+
+export async function readCapabilities(
+  cookieHeader: string | undefined,
+  secret: string,
+): Promise<Capabilities | null> {
+  if (!cookieHeader) return null;
+
+  const match = cookieHeader.match(new RegExp(`${COOKIE_NAME}=([^;]+)`));
+  if (!match?.[1]) return null;
+
+  return verify(match[1], secret);
+}


### PR DESCRIPTION
## Summary

Session cookie (better-auth cookieCache) handles identity. Capabilities cookie (HMAC-signed, 5 min TTL) carries org role and admin status, avoiding D1 queries on every protected route.

- `capabilities.ts`: HMAC sign/verify with Web Crypto API, Zod-validated payload, base64 encoding
- `loadSession` middleware: reads capabilities cookie first, falls back to D1 member query on miss, sets cookie for subsequent requests
- New middleware exports: `requireOrgMember`, `requireOrgRole(...roles)`, `requireAdmin`
- Capabilities in HonoEnv Variables for type-safe access via `c.var.capabilities`

Cookie payload: `{ userId, orgId, role, isAdmin, iat }` -- minimal, no PII.

Closes #5

## Test plan

- [ ] Verify capabilities cookie is set after login with active org
- [ ] Verify D1 is not queried when valid capabilities cookie exists
- [ ] Verify expired cookie (>5 min) triggers D1 refresh
- [ ] Verify HMAC signature prevents tampering
- [ ] Verify requireOrgRole middleware blocks unauthorized access
- [ ] Verify requireAdmin middleware checks isAdmin flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)