### PR TITLE
Scaffold ctrl routes, layout, and auth gate

### DIFF
--- a/apps/web/src/layouts/Ctrl.astro
+++ b/apps/web/src/layouts/Ctrl.astro
@@ -1,0 +1,40 @@
+---
+import "../styles/global.css";
+import Nav from "../components/Nav.astro";
+
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>{title} -- ctrl</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body class="flex flex-col min-h-screen">
+    <nav class="border-b border-border px-6 py-3 flex items-center gap-6">
+      <a href="/ctrl" class="text-sm font-medium text-foreground">ctrl</a>
+      <div class="flex gap-4 text-sm text-muted-foreground">
+        <a href="/ctrl/team">Team</a>
+        <a href="/ctrl/content">Content</a>
+        <a href="/ctrl/email">Email</a>
+        <a href="/ctrl/listen">Listen</a>
+      </div>
+    </nav>
+    <main class="flex-1 max-w-5xl mx-auto w-full px-6 py-8">
+      <slot />
+    </main>
+  </body>
+</html>

--- a/apps/web/src/pages/ctrl/content.astro
+++ b/apps/web/src/pages/ctrl/content.astro
@@ -1,0 +1,10 @@
+---
+import Ctrl from "../../layouts/Ctrl.astro";
+
+export const prerender = false;
+---
+
+<Ctrl title="Content">
+  <h1 class="text-2xl mb-6">Content</h1>
+  <p class="text-muted-foreground">Gitpress content editor. Phase 2.</p>
+</Ctrl>

--- a/apps/web/src/pages/ctrl/email.astro
+++ b/apps/web/src/pages/ctrl/email.astro
@@ -1,0 +1,10 @@
+---
+import Ctrl from "../../layouts/Ctrl.astro";
+
+export const prerender = false;
+---
+
+<Ctrl title="Email">
+  <h1 class="text-2xl mb-6">Email</h1>
+  <p class="text-muted-foreground">Unified inbox. Phase 2.</p>
+</Ctrl>

--- a/apps/web/src/pages/ctrl/index.astro
+++ b/apps/web/src/pages/ctrl/index.astro
@@ -1,0 +1,46 @@
+---
+import Ctrl from "../../layouts/Ctrl.astro";
+
+export const prerender = false;
+---
+
+<Ctrl title="Dashboard">
+  <h1 class="text-2xl mb-6">ctrl</h1>
+  <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+    <a
+      href="/ctrl/team"
+      class="flex flex-col gap-2 rounded-lg border border-border p-6 hover:border-foreground transition-colors"
+    >
+      <span class="text-sm font-medium">Team</span>
+      <span class="text-sm text-muted-foreground">Bullpen, status, tasks</span>
+    </a>
+    <a
+      href="/ctrl/content"
+      class="flex flex-col gap-2 rounded-lg border border-border p-6 hover:border-foreground transition-colors"
+    >
+      <span class="text-sm font-medium">Content</span>
+      <span class="text-sm text-muted-foreground">Edit and publish across sites</span>
+    </a>
+    <a
+      href="/ctrl/email"
+      class="flex flex-col gap-2 rounded-lg border border-border p-6 hover:border-foreground transition-colors"
+    >
+      <span class="text-sm font-medium">Email</span>
+      <span class="text-sm text-muted-foreground">Inbox, newsletters, campaigns</span>
+    </a>
+    <a
+      href="/ctrl/listen"
+      class="flex flex-col gap-2 rounded-lg border border-border p-6 hover:border-foreground transition-colors"
+    >
+      <span class="text-sm font-medium">Listen</span>
+      <span class="text-sm text-muted-foreground">Discourse intelligence</span>
+    </a>
+    <a
+      href="/ctrl/settings"
+      class="flex flex-col gap-2 rounded-lg border border-border p-6 hover:border-foreground transition-colors"
+    >
+      <span class="text-sm font-medium">Settings</span>
+      <span class="text-sm text-muted-foreground">Auth, billing, domains</span>
+    </a>
+  </div>
+</Ctrl>

--- a/apps/web/src/pages/ctrl/listen.astro
+++ b/apps/web/src/pages/ctrl/listen.astro
@@ -1,0 +1,10 @@
+---
+import Ctrl from "../../layouts/Ctrl.astro";
+
+export const prerender = false;
+---
+
+<Ctrl title="Listen">
+  <h1 class="text-2xl mb-6">Listen</h1>
+  <p class="text-muted-foreground">Discourse intelligence. Phase 3.</p>
+</Ctrl>

--- a/apps/web/src/pages/ctrl/settings.astro
+++ b/apps/web/src/pages/ctrl/settings.astro
@@ -1,0 +1,10 @@
+---
+import Ctrl from "../../layouts/Ctrl.astro";
+
+export const prerender = false;
+---
+
+<Ctrl title="Settings">
+  <h1 class="text-2xl mb-6">Settings</h1>
+  <p class="text-muted-foreground">Auth, billing, domains. Phase 5.</p>
+</Ctrl>

--- a/apps/web/src/pages/ctrl/team.astro
+++ b/apps/web/src/pages/ctrl/team.astro
@@ -1,0 +1,17 @@
+---
+import Ctrl from "../../layouts/Ctrl.astro";
+
+export const prerender = false;
+---
+
+<Ctrl title="Team">
+  <h1 class="text-2xl mb-6">Team</h1>
+  <div class="flex flex-col gap-6">
+    <section>
+      <h2 class="text-lg mb-3">Bullpen</h2>
+      <div id="bullpen" class="flex flex-col gap-2 text-sm">
+        <p class="text-muted-foreground">Legion SSE integration pending. Connect to legion bullpen endpoint.</p>
+      </div>
+    </section>
+  </div>
+</Ctrl>


### PR DESCRIPTION
## Summary

Phase 1 ctrl shell per the ctrl plan (vault-2026/projects/ctrl/ctrl-plan.md).

- Ctrl layout with nav linking all surfaces
- Auth gate via Astro middleware -- all /ctrl/* routes check better-auth session, redirect to GitHub OAuth if unauthenticated
- Route stubs for dashboard, team, content, email, listen, settings
- /ctrl dashboard with surface cards
- noindex meta tag (internal tool)
- Fix: increase Node heap to 4GB for typecheck (worker-configuration.d.ts OOM)

Next: React islands for team surface, then content editor.

Partial progress on #16.

## Test plan

- [ ] /ctrl redirects to GitHub OAuth when not authenticated
- [ ] /ctrl shows dashboard with surface cards when authenticated
- [ ] All hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)