### PR TITLE
Uncertainty engine: Drizzle schema + zod companion (#98)

### DIFF
--- a/apps/web/src/db/schema/uncertainty.ts
+++ b/apps/web/src/db/schema/uncertainty.ts
@@ -1,0 +1,56 @@
+import { sql } from "drizzle-orm";
+import { index, integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { uuidv7 } from "uuidv7";
+
+export const uncertaintyPrediction = sqliteTable(
+  "uncertainty_prediction",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => uuidv7()),
+    surface: text("surface").notNull(),
+    featureKey: text("feature_key").notNull(),
+    inputFingerprint: text("input_fingerprint").notNull(),
+    model: text("model").notNull(),
+    modelVersion: text("model_version").notNull(),
+    claimedConfidence: real("claimed_confidence").notNull(),
+    predictionPayload: text("prediction_payload", { mode: "json" }).notNull(),
+    state: text("state", { enum: ["emitted", "witnessed", "orphaned", "retired"] }).notNull(),
+    outcomeLabel: text("outcome_label"),
+    outcomePayload: text("outcome_payload", { mode: "json" }),
+    outcomeCorrectness: real("outcome_correctness"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    witnessedAt: integer("witnessed_at", { mode: "timestamp_ms" }),
+    orphanAfter: integer("orphan_after", { mode: "timestamp_ms" }).notNull(),
+    cohortKey: text("cohort_key").notNull(),
+  },
+  (table) => [
+    index("idx_uncertainty_prediction_cohort").on(table.cohortKey),
+    index("idx_uncertainty_prediction_surface").on(table.surface),
+    index("idx_uncertainty_prediction_state").on(table.state),
+    index("idx_uncertainty_prediction_orphan_sweep").on(table.state, table.orphanAfter),
+  ],
+);
+
+export const uncertaintyCalibrationSnapshot = sqliteTable(
+  "uncertainty_calibration_snapshot",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => uuidv7()),
+    cohortKey: text("cohort_key").notNull(),
+    bucketLower: real("bucket_lower").notNull(),
+    bucketUpper: real("bucket_upper").notNull(),
+    claimedConfidence: real("claimed_confidence").notNull(),
+    actualCorrectness: real("actual_correctness").notNull(),
+    predictionCount: integer("prediction_count").notNull(),
+    orphanCount: integer("orphan_count").notNull(),
+    brierScore: real("brier_score").notNull(),
+    computedAt: integer("computed_at", { mode: "timestamp_ms" })
+      .notNull()
+      .default(sql`(cast(unixepoch('subsecond') * 1000 as integer))`),
+  },
+  (table) => [index("idx_uncertainty_calibration_snapshot_cohort").on(table.cohortKey)],
+);

--- a/apps/web/src/db/schema/uncertainty.zod.ts
+++ b/apps/web/src/db/schema/uncertainty.zod.ts
@@ -1,0 +1,49 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { uncertaintyCalibrationSnapshot, uncertaintyPrediction } from "./uncertainty";
+
+export const predictionStateSchema = z.enum(["emitted", "witnessed", "orphaned", "retired"]);
+
+export const outcomeLabelSchema = z.enum(["accepted", "rejected", "edited", "ignored", "custom"]);
+
+export const surfaceSchema = z.string().min(1).max(64);
+
+export const insertUncertaintyPredictionSchema = createInsertSchema(uncertaintyPrediction, {
+  claimedConfidence: z.number().min(0).max(1),
+  outcomeCorrectness: z.number().min(0).max(1).nullable().optional(),
+  state: predictionStateSchema,
+});
+
+export const selectUncertaintyPredictionSchema = createSelectSchema(uncertaintyPrediction, {
+  claimedConfidence: z.number().min(0).max(1),
+  outcomeCorrectness: z.number().min(0).max(1).nullable(),
+  state: predictionStateSchema,
+});
+
+export const insertUncertaintyCalibrationSnapshotSchema = createInsertSchema(
+  uncertaintyCalibrationSnapshot,
+  {
+    bucketLower: z.number().min(0).max(1),
+    bucketUpper: z.number().min(0).max(1),
+    claimedConfidence: z.number().min(0).max(1),
+    actualCorrectness: z.number().min(0).max(1),
+    predictionCount: z.number().int().nonnegative(),
+    orphanCount: z.number().int().nonnegative(),
+    brierScore: z.number().min(0).max(1),
+  },
+);
+
+export const selectUncertaintyCalibrationSnapshotSchema = createSelectSchema(
+  uncertaintyCalibrationSnapshot,
+);
+
+export type InsertUncertaintyPrediction = z.infer<typeof insertUncertaintyPredictionSchema>;
+export type SelectUncertaintyPrediction = z.infer<typeof selectUncertaintyPredictionSchema>;
+export type InsertUncertaintyCalibrationSnapshot = z.infer<
+  typeof insertUncertaintyCalibrationSnapshotSchema
+>;
+export type SelectUncertaintyCalibrationSnapshot = z.infer<
+  typeof selectUncertaintyCalibrationSnapshotSchema
+>;
+export type PredictionState = z.infer<typeof predictionStateSchema>;
+export type OutcomeLabel = z.infer<typeof outcomeLabelSchema>;


### PR DESCRIPTION
Closes #98. Stacks on #108.

apps/web/src/db/schema/uncertainty.ts mirrors the migration column shapes -- timestamp_ms mode on time fields, json mode on payload columns, enum constraint on state.

apps/web/src/db/schema/uncertainty.zod.ts narrows inserts/selects with bounded confidence and correctness ranges (0..1) and surfaces the predictionState and outcomeLabel enums for handler use.

No barrel files; consumers import from the specific schema file.