### PR TITLE
chore: drop orphan @rafters/* link deps from apps/ctrl

### DIFF
--- a/apps/ctrl/package.json
+++ b/apps/ctrl/package.json
@@ -8,8 +8,6 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@rafters/color-utils": "link:/Volumes/store/projects/rafters-studio/rafters/packages/color-utils",
-    "@rafters/shared": "link:/Volumes/store/projects/rafters-studio/rafters/packages/shared",
     "@tanstack/react-query": "^5.91.0",
     "@tanstack/react-router": "^1.168.10",
     "@tanstack/router-zod-adapter": "^1.81.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,12 +26,6 @@ importers:
 
   apps/ctrl:
     dependencies:
-      '@rafters/color-utils':
-        specifier: link:/Volumes/store/projects/rafters-studio/rafters/packages/color-utils
-        version: link:../../../rafters/packages/color-utils
-      '@rafters/shared':
-        specifier: link:/Volumes/store/projects/rafters-studio/rafters/packages/shared
-        version: link:../../../rafters/packages/shared
       '@tanstack/react-query':
         specifier: ^5.91.0
         version: 5.91.0(react@19.2.4)


### PR DESCRIPTION
The link: deps for @rafters/color-utils and @rafters/shared landed in 47bf106 with the rationale 'for the color intelligence viewer' and a follow-up plan to 'switch to npm registry references once the packages are published.' Neither happened: no viewer was specced or written (apps/ctrl/src has zero @rafters imports), and the publish direction reversed -- rafters internal packages are not consumable from outside the rafters workspace under any protocol.

A later legion reflection (019d65d7) misread these orphans as 'the apps/ctrl link: precedent' and froze them into doctrine, which caused this session to almost extend the same mistake into @rafters/ui. Deleting the orphans here so the doctrine has nothing to anchor to. A correction reflection has been recorded against 019d65d7.