### PR TITLE
feat: Drizzle schema + zod companions for uncertainty engine (#98)

### DIFF
--- a/apps/web/src/db/schema/uncertainty.ts
+++ b/apps/web/src/db/schema/uncertainty.ts
@@ -1,0 +1,55 @@
+import { index, integer, real, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { uuidv7 } from "uuidv7";
+
+export const uncertaintyPrediction = sqliteTable(
+  "uncertainty_prediction",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => uuidv7()),
+    surface: text("surface").notNull(),
+    featureKey: text("feature_key").notNull(),
+    inputFingerprint: text("input_fingerprint").notNull(),
+    model: text("model").notNull(),
+    modelVersion: text("model_version").notNull(),
+    claimedConfidence: real("claimed_confidence").notNull(),
+    predictionPayload: text("prediction_payload").notNull(),
+    state: text("state").notNull(),
+    outcomeLabel: text("outcome_label"),
+    outcomePayload: text("outcome_payload"),
+    outcomeCorrectness: real("outcome_correctness"),
+    createdAt: integer("created_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+    witnessedAt: integer("witnessed_at", { mode: "timestamp_ms" }),
+    orphanAfter: integer("orphan_after", { mode: "timestamp_ms" }).notNull(),
+    cohortKey: text("cohort_key").notNull(),
+  },
+  (table) => [
+    index("idx_uncertainty_prediction_cohort").on(table.cohortKey),
+    index("idx_uncertainty_prediction_surface").on(table.surface),
+    index("idx_uncertainty_prediction_state").on(table.state),
+    index("idx_uncertainty_prediction_orphan_sweep").on(table.state, table.orphanAfter),
+  ],
+);
+
+export const uncertaintyCalibrationSnapshot = sqliteTable(
+  "uncertainty_calibration_snapshot",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => uuidv7()),
+    cohortKey: text("cohort_key").notNull(),
+    bucketLower: real("bucket_lower").notNull(),
+    bucketUpper: real("bucket_upper").notNull(),
+    claimedConfidence: real("claimed_confidence").notNull(),
+    actualCorrectness: real("actual_correctness").notNull(),
+    predictionCount: integer("prediction_count").notNull(),
+    orphanCount: integer("orphan_count").notNull(),
+    brierScore: real("brier_score").notNull(),
+    computedAt: integer("computed_at", { mode: "timestamp_ms" })
+      .notNull()
+      .$defaultFn(() => new Date()),
+  },
+  (table) => [index("idx_uncertainty_calibration_snapshot_cohort").on(table.cohortKey)],
+);

--- a/apps/web/src/db/schema/uncertainty.zod.ts
+++ b/apps/web/src/db/schema/uncertainty.zod.ts
@@ -4,45 +4,40 @@ import { uncertaintyCalibrationSnapshot, uncertaintyPrediction } from "./uncerta
 
 const predictionState = z.enum(["emitted", "witnessed", "orphaned", "retired"]);
 const outcomeLabel = z.enum(["accepted", "rejected", "edited", "ignored", "custom"]);
+const unitInterval = z.number().min(0).max(1);
+
+const calibrationSnapshotOverrides = {
+  bucketLower: unitInterval,
+  bucketUpper: unitInterval,
+  claimedConfidence: unitInterval,
+  actualCorrectness: unitInterval,
+  predictionCount: z.number().int().nonnegative(),
+  orphanCount: z.number().int().nonnegative(),
+  brierScore: unitInterval,
+};
 
 export const insertUncertaintyPredictionSchema = createInsertSchema(uncertaintyPrediction, {
   state: predictionState,
   outcomeLabel: outcomeLabel.nullable().optional(),
-  claimedConfidence: z.number().min(0).max(1),
-  outcomeCorrectness: z.number().min(0).max(1).nullable().optional(),
+  claimedConfidence: unitInterval,
+  outcomeCorrectness: unitInterval.nullable().optional(),
 });
 
 export const selectUncertaintyPredictionSchema = createSelectSchema(uncertaintyPrediction, {
   state: predictionState,
   outcomeLabel: outcomeLabel.nullable(),
-  claimedConfidence: z.number().min(0).max(1),
-  outcomeCorrectness: z.number().min(0).max(1).nullable(),
+  claimedConfidence: unitInterval,
+  outcomeCorrectness: unitInterval.nullable(),
 });
 
 export const insertUncertaintyCalibrationSnapshotSchema = createInsertSchema(
   uncertaintyCalibrationSnapshot,
-  {
-    bucketLower: z.number().min(0).max(1),
-    bucketUpper: z.number().min(0).max(1),
-    claimedConfidence: z.number().min(0).max(1),
-    actualCorrectness: z.number().min(0).max(1),
-    predictionCount: z.number().int().nonnegative(),
-    orphanCount: z.number().int().nonnegative(),
-    brierScore: z.number().min(0).max(1),
-  },
+  calibrationSnapshotOverrides,
 );
 
 export const selectUncertaintyCalibrationSnapshotSchema = createSelectSchema(
   uncertaintyCalibrationSnapshot,
-  {
-    bucketLower: z.number().min(0).max(1),
-    bucketUpper: z.number().min(0).max(1),
-    claimedConfidence: z.number().min(0).max(1),
-    actualCorrectness: z.number().min(0).max(1),
-    predictionCount: z.number().int().nonnegative(),
-    orphanCount: z.number().int().nonnegative(),
-    brierScore: z.number().min(0).max(1),
-  },
+  calibrationSnapshotOverrides,
 );
 
 export type InsertUncertaintyPrediction = z.infer<typeof insertUncertaintyPredictionSchema>;

--- a/apps/web/src/db/schema/uncertainty.zod.ts
+++ b/apps/web/src/db/schema/uncertainty.zod.ts
@@ -1,0 +1,55 @@
+import { createInsertSchema, createSelectSchema } from "drizzle-zod";
+import { z } from "zod";
+import { uncertaintyCalibrationSnapshot, uncertaintyPrediction } from "./uncertainty";
+
+const predictionState = z.enum(["emitted", "witnessed", "orphaned", "retired"]);
+const outcomeLabel = z.enum(["accepted", "rejected", "edited", "ignored", "custom"]);
+
+export const insertUncertaintyPredictionSchema = createInsertSchema(uncertaintyPrediction, {
+  state: predictionState,
+  outcomeLabel: outcomeLabel.nullable().optional(),
+  claimedConfidence: z.number().min(0).max(1),
+  outcomeCorrectness: z.number().min(0).max(1).nullable().optional(),
+});
+
+export const selectUncertaintyPredictionSchema = createSelectSchema(uncertaintyPrediction, {
+  state: predictionState,
+  outcomeLabel: outcomeLabel.nullable(),
+  claimedConfidence: z.number().min(0).max(1),
+  outcomeCorrectness: z.number().min(0).max(1).nullable(),
+});
+
+export const insertUncertaintyCalibrationSnapshotSchema = createInsertSchema(
+  uncertaintyCalibrationSnapshot,
+  {
+    bucketLower: z.number().min(0).max(1),
+    bucketUpper: z.number().min(0).max(1),
+    claimedConfidence: z.number().min(0).max(1),
+    actualCorrectness: z.number().min(0).max(1),
+    predictionCount: z.number().int().nonnegative(),
+    orphanCount: z.number().int().nonnegative(),
+    brierScore: z.number().min(0).max(1),
+  },
+);
+
+export const selectUncertaintyCalibrationSnapshotSchema = createSelectSchema(
+  uncertaintyCalibrationSnapshot,
+  {
+    bucketLower: z.number().min(0).max(1),
+    bucketUpper: z.number().min(0).max(1),
+    claimedConfidence: z.number().min(0).max(1),
+    actualCorrectness: z.number().min(0).max(1),
+    predictionCount: z.number().int().nonnegative(),
+    orphanCount: z.number().int().nonnegative(),
+    brierScore: z.number().min(0).max(1),
+  },
+);
+
+export type InsertUncertaintyPrediction = z.infer<typeof insertUncertaintyPredictionSchema>;
+export type SelectUncertaintyPrediction = z.infer<typeof selectUncertaintyPredictionSchema>;
+export type InsertUncertaintyCalibrationSnapshot = z.infer<
+  typeof insertUncertaintyCalibrationSnapshotSchema
+>;
+export type SelectUncertaintyCalibrationSnapshot = z.infer<
+  typeof selectUncertaintyCalibrationSnapshotSchema
+>;


### PR DESCRIPTION
Closes #98.

Two schema files matching the 0002_uncertainty_engine.sql migration column-for-column:

- `uncertainty.ts` -- Drizzle table definitions with index declarations mirroring the migration
- `uncertainty.zod.ts` -- insert/select schemas via drizzle-zod; state and outcome_label constrained as enums, all confidence/correctness/brier columns bounded 0-1 via shared unitInterval constant

The calibration snapshot insert and select overrides share a single `calibrationSnapshotOverrides` object -- no duplication. TypeScript inferred types exported for all four shapes.