### PR TITLE
feat: uncertainty engine routes, crons, and ctrl debug page (#99-103)

### DIFF
--- a/apps/ctrl/src/routes/_ctrl/uncertainty.tsx
+++ b/apps/ctrl/src/routes/_ctrl/uncertainty.tsx
@@ -1,0 +1,114 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
+import { z } from "zod";
+
+const calibrationRowSchema = z.object({
+  id: z.string(),
+  cohortKey: z.string(),
+  bucketLower: z.number(),
+  bucketUpper: z.number(),
+  claimedConfidence: z.number(),
+  actualCorrectness: z.number(),
+  predictionCount: z.number(),
+  orphanCount: z.number(),
+  brierScore: z.number(),
+  computedAt: z.number(),
+});
+
+type CalibrationRow = z.infer<typeof calibrationRowSchema>;
+
+const surfaceOptions = [
+  "rafters.color",
+  "eavesdrop.classify",
+  "mail.deliverability",
+  "ctrl.decision",
+] as const;
+
+async function fetchCalibration(surface: string, model: string): Promise<CalibrationRow[]> {
+  const params = new URLSearchParams({ surface, model });
+  const res = await fetch(`/api/uncertainty/calibration?${params}`);
+  if (!res.ok) throw new Error(`${res.status}`);
+  const raw = await res.json();
+  return z.array(calibrationRowSchema).parse(raw);
+}
+
+export const Route = createFileRoute("/_ctrl/uncertainty")({
+  component: UncertaintyPage,
+});
+
+function UncertaintyPage() {
+  const [surface, setSurface] = useState<string>(surfaceOptions[0]);
+  const [model, setModel] = useState<string>("claude-sonnet-4-6");
+
+  const { data, isPending, error } = useQuery({
+    queryKey: ["uncertainty", "calibration", surface, model],
+    queryFn: () => fetchCalibration(surface, model),
+    enabled: !!surface && !!model,
+  });
+
+  return (
+    <main>
+      <h1>Uncertainty calibration</h1>
+
+      <div>
+        <label htmlFor="surface-select">Surface</label>
+        <select id="surface-select" value={surface} onChange={(e) => setSurface(e.target.value)}>
+          {surfaceOptions.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+
+        <label htmlFor="model-input">Model</label>
+        <input
+          id="model-input"
+          type="text"
+          value={model}
+          onChange={(e) => setModel(e.target.value)}
+          placeholder="claude-sonnet-4-6"
+        />
+      </div>
+
+      {isPending && <p aria-live="polite">Loading calibration data...</p>}
+      {error && <p role="alert">Failed to load: {error.message}</p>}
+
+      {data && data.length === 0 && (
+        <p>No calibration data yet for this cohort. Predictions need to be witnessed first.</p>
+      )}
+
+      {data && data.length > 0 && (
+        <table>
+          <caption>
+            Reliability by confidence bucket &mdash; {surface} / {model}
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Bucket</th>
+              <th scope="col">Claimed mean</th>
+              <th scope="col">Actual mean</th>
+              <th scope="col">Count</th>
+              <th scope="col">Orphans</th>
+              <th scope="col">Brier</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.map((row) => (
+              <tr key={row.id}>
+                <td>
+                  {row.bucketLower.toFixed(1)}&ndash;{row.bucketUpper.toFixed(1)}
+                </td>
+                <td>{row.claimedConfidence.toFixed(2)}</td>
+                <td>{row.actualCorrectness.toFixed(2)}</td>
+                <td>{row.predictionCount}</td>
+                <td>{row.orphanCount}</td>
+                <td>{row.brierScore.toFixed(3)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </main>
+  );
+}

--- a/apps/web/src/api/app.ts
+++ b/apps/web/src/api/app.ts
@@ -7,6 +7,7 @@ import { loadSession } from "./middleware/auth";
 import { authRoutes } from "./routes/auth";
 import { colorRoutes } from "./routes/color";
 import { ctrlRoutes } from "./routes/ctrl/index";
+import { uncertaintyRoutes } from "./routes/uncertainty";
 import type { HonoEnv } from "./types";
 
 const app = new Hono<HonoEnv>()
@@ -15,7 +16,8 @@ const app = new Hono<HonoEnv>()
   .route("/auth", authRoutes)
   .use("/*", loadSession)
   .route("/color", colorRoutes)
-  .route("/ctrl", ctrlRoutes);
+  .route("/ctrl", ctrlRoutes)
+  .route("/uncertainty", uncertaintyRoutes);
 
 export type AppType = typeof app;
 export default app;

--- a/apps/web/src/api/cron/calibration-roll.ts
+++ b/apps/web/src/api/cron/calibration-roll.ts
@@ -1,0 +1,109 @@
+import { and, eq, sql } from "drizzle-orm";
+import { createDb } from "../../db/client";
+import { uncertaintyCalibrationSnapshot, uncertaintyPrediction } from "../../db/schema/uncertainty";
+
+export const BUCKETS = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0] as const;
+
+export type BucketRow = {
+  bucketLower: number;
+  bucketUpper: number;
+  claimedConfidence: number;
+  actualCorrectness: number;
+  predictionCount: number;
+  brierScore: number;
+};
+
+export function computeBuckets(
+  predictions: { claimedConfidence: number; outcomeCorrectness: number | null }[],
+): BucketRow[] {
+  const rows: BucketRow[] = [];
+
+  for (let i = 0; i < BUCKETS.length - 1; i++) {
+    const lower = BUCKETS[i];
+    const upper = BUCKETS[i + 1];
+
+    const bucket = predictions.filter(
+      (p) => p.claimedConfidence >= lower && p.claimedConfidence < upper,
+    );
+
+    if (bucket.length === 0) continue;
+
+    const claimedMean = bucket.reduce((s, p) => s + p.claimedConfidence, 0) / bucket.length;
+    const correctnessMean =
+      bucket.reduce((s, p) => s + (p.outcomeCorrectness ?? 0), 0) / bucket.length;
+    const brierScore =
+      bucket.reduce((s, p) => s + (p.claimedConfidence - (p.outcomeCorrectness ?? 0)) ** 2, 0) /
+      bucket.length;
+
+    rows.push({
+      bucketLower: lower,
+      bucketUpper: upper,
+      claimedConfidence: claimedMean,
+      actualCorrectness: correctnessMean,
+      predictionCount: bucket.length,
+      brierScore,
+    });
+  }
+
+  return rows;
+}
+
+export async function runCalibrationRoll(d1: D1Database): Promise<number> {
+  const db = createDb(d1);
+
+  const cohorts = await db
+    .selectDistinct({ cohortKey: uncertaintyPrediction.cohortKey })
+    .from(uncertaintyPrediction)
+    .where(eq(uncertaintyPrediction.state, "witnessed"))
+    .all();
+
+  let snapshotCount = 0;
+
+  for (const { cohortKey } of cohorts) {
+    const witnessed = await db
+      .select({
+        claimedConfidence: uncertaintyPrediction.claimedConfidence,
+        outcomeCorrectness: uncertaintyPrediction.outcomeCorrectness,
+      })
+      .from(uncertaintyPrediction)
+      .where(
+        and(
+          eq(uncertaintyPrediction.cohortKey, cohortKey),
+          eq(uncertaintyPrediction.state, "witnessed"),
+        ),
+      )
+      .all();
+
+    const orphanCount = await db
+      .select({ count: sql<number>`count(*)` })
+      .from(uncertaintyPrediction)
+      .where(
+        and(
+          eq(uncertaintyPrediction.cohortKey, cohortKey),
+          eq(uncertaintyPrediction.state, "orphaned"),
+        ),
+      )
+      .get();
+
+    const totalOrphans = orphanCount?.count ?? 0;
+
+    await db
+      .delete(uncertaintyCalibrationSnapshot)
+      .where(eq(uncertaintyCalibrationSnapshot.cohortKey, cohortKey));
+
+    const buckets = computeBuckets(witnessed);
+    const rows = buckets.map((b) => ({
+      cohortKey,
+      ...b,
+      orphanCount: totalOrphans,
+      computedAt: new Date(),
+    }));
+
+    if (rows.length > 0) {
+      await db.insert(uncertaintyCalibrationSnapshot).values(rows);
+      snapshotCount += rows.length;
+    }
+  }
+
+  return snapshotCount;
+}

--- a/apps/web/src/api/cron/orphan-sweep.ts
+++ b/apps/web/src/api/cron/orphan-sweep.ts
@@ -1,0 +1,18 @@
+import { and, eq, lt } from "drizzle-orm";
+import { createDb } from "../../db/client";
+import { uncertaintyPrediction } from "../../db/schema/uncertainty";
+
+export async function runOrphanSweep(d1: D1Database): Promise<number> {
+  const db = createDb(d1);
+  const now = new Date();
+
+  const result = await db
+    .update(uncertaintyPrediction)
+    .set({ state: "orphaned" })
+    .where(
+      and(eq(uncertaintyPrediction.state, "emitted"), lt(uncertaintyPrediction.orphanAfter, now)),
+    )
+    .returning({ id: uncertaintyPrediction.id });
+
+  return result.length;
+}

--- a/apps/web/src/api/routes/uncertainty.ts
+++ b/apps/web/src/api/routes/uncertainty.ts
@@ -1,0 +1,136 @@
+import { zValidator } from "@hono/zod-validator";
+import { and, eq, gte, lt, sql } from "drizzle-orm";
+import { Hono } from "hono";
+import { z } from "zod";
+import { createDb } from "../../db/client";
+import { uncertaintyCalibrationSnapshot, uncertaintyPrediction } from "../../db/schema/uncertainty";
+import { requireAuth } from "../middleware/auth";
+import type { HonoEnv } from "../types";
+
+export const emitSchema = z.object({
+  surface: z.string().min(1),
+  feature_key: z.string().min(1),
+  input_fingerprint: z.string().min(1),
+  model: z.string().min(1),
+  model_version: z.string().min(1),
+  claimed_confidence: z.number().min(0).max(1),
+  prediction_payload: z.unknown(),
+  orphan_ttl_days: z.number().int().positive().optional().default(30),
+});
+
+export const witnessSchema = z.object({
+  outcome_label: z.enum(["accepted", "rejected", "edited", "ignored", "custom"]),
+  outcome_correctness: z.number().min(0).max(1),
+  outcome_payload: z.unknown().optional(),
+});
+
+const calibrationQuerySchema = z.object({
+  surface: z.string().min(1),
+  model: z.string().min(1),
+  model_version: z.string().optional(),
+});
+
+const orphansQuerySchema = z.object({
+  surface: z.string().min(1).optional(),
+});
+
+export const uncertaintyRoutes = new Hono<HonoEnv>()
+  .use("/*", requireAuth)
+
+  .post("/predictions", zValidator("json", emitSchema), async (c) => {
+    const body = c.req.valid("json");
+    const db = createDb(c.env.DB);
+
+    const orphanAfter = new Date(Date.now() + body.orphan_ttl_days * 24 * 60 * 60 * 1000);
+    const cohortKey = `${body.surface}::${body.model}::${body.model_version}`;
+
+    const [row] = await db
+      .insert(uncertaintyPrediction)
+      .values({
+        surface: body.surface,
+        featureKey: body.feature_key,
+        inputFingerprint: body.input_fingerprint,
+        model: body.model,
+        modelVersion: body.model_version,
+        claimedConfidence: body.claimed_confidence,
+        predictionPayload: JSON.stringify(body.prediction_payload),
+        state: "emitted",
+        orphanAfter,
+        cohortKey,
+      })
+      .returning({ id: uncertaintyPrediction.id, orphanAfter: uncertaintyPrediction.orphanAfter });
+
+    return c.json({ id: row.id, orphan_after: row.orphanAfter });
+  })
+
+  .put("/predictions/:id/witness", zValidator("json", witnessSchema), async (c) => {
+    const id = c.req.param("id");
+    const body = c.req.valid("json");
+    const db = createDb(c.env.DB);
+
+    const existing = await db
+      .select({ state: uncertaintyPrediction.state })
+      .from(uncertaintyPrediction)
+      .where(eq(uncertaintyPrediction.id, id))
+      .get();
+
+    if (!existing) return c.json({ error: "Not found" }, 404);
+    if (existing.state === "witnessed") return c.json({ error: "Already witnessed" }, 409);
+
+    await db
+      .update(uncertaintyPrediction)
+      .set({
+        state: "witnessed",
+        outcomeLabel: body.outcome_label,
+        outcomeCorrectness: body.outcome_correctness,
+        outcomePayload: body.outcome_payload ? JSON.stringify(body.outcome_payload) : null,
+        witnessedAt: new Date(),
+      })
+      .where(eq(uncertaintyPrediction.id, id));
+
+    return c.json({ ok: true });
+  })
+
+  .get("/calibration", zValidator("query", calibrationQuerySchema), async (c) => {
+    const { surface, model, model_version } = c.req.valid("query");
+    const db = createDb(c.env.DB);
+
+    const cohortKey = model_version ? `${surface}::${model}::${model_version}` : undefined;
+
+    const rows = await db
+      .select()
+      .from(uncertaintyCalibrationSnapshot)
+      .where(
+        cohortKey
+          ? eq(uncertaintyCalibrationSnapshot.cohortKey, cohortKey)
+          : and(
+              gte(uncertaintyCalibrationSnapshot.cohortKey, `${surface}::${model}::`),
+              lt(uncertaintyCalibrationSnapshot.cohortKey, `${surface}::${model}:;`),
+            ),
+      )
+      .all();
+
+    return c.json(rows);
+  })
+
+  .get("/orphans", zValidator("query", orphansQuerySchema), async (c) => {
+    const { surface } = c.req.valid("query");
+    const db = createDb(c.env.DB);
+
+    const rows = await db
+      .select({
+        surface: uncertaintyPrediction.surface,
+        orphan_count: sql<number>`count(*)`,
+      })
+      .from(uncertaintyPrediction)
+      .where(
+        and(
+          eq(uncertaintyPrediction.state, "orphaned"),
+          surface ? eq(uncertaintyPrediction.surface, surface) : undefined,
+        ),
+      )
+      .groupBy(uncertaintyPrediction.surface)
+      .all();
+
+    return c.json(rows);
+  });

--- a/apps/web/src/db/client.ts
+++ b/apps/web/src/db/client.ts
@@ -1,8 +1,9 @@
 import { type DrizzleD1Database, drizzle } from "drizzle-orm/d1";
 import * as authSchema from "./schema/auth";
 import * as auditSchema from "./schema/audit";
+import * as uncertaintySchema from "./schema/uncertainty";
 
-const schema = { ...authSchema, ...auditSchema };
+const schema = { ...authSchema, ...auditSchema, ...uncertaintySchema };
 
 export type Database = DrizzleD1Database<typeof schema>;
 

--- a/apps/web/src/pages/api/[...slug].ts
+++ b/apps/web/src/pages/api/[...slug].ts
@@ -4,6 +4,7 @@ import { Hono } from "hono";
 import { createAuth } from "../../api/auth";
 import { colorRoutes } from "../../api/routes/color";
 import { ctrlRoutes } from "../../api/routes/ctrl/index";
+import { uncertaintyRoutes } from "../../api/routes/uncertainty";
 import { loadSession } from "../../api/middleware/auth";
 import { requestLogger } from "../../lib/logging/middleware";
 import type { HonoEnv } from "../../api/types";
@@ -26,6 +27,7 @@ app.use("/*", loadSession);
 
 app.route("/color", colorRoutes);
 app.route("/ctrl", ctrlRoutes);
+app.route("/uncertainty", uncertaintyRoutes);
 
 const handle: APIRoute = (context) => app.fetch(context.request, env);
 

--- a/apps/web/src/worker-entry.ts
+++ b/apps/web/src/worker-entry.ts
@@ -1,0 +1,15 @@
+export { default } from "@astrojs/cloudflare/entrypoints/server";
+
+import { runOrphanSweep } from "./api/cron/orphan-sweep";
+import { runCalibrationRoll } from "./api/cron/calibration-roll";
+
+export const scheduled: ExportedHandlerScheduledHandler<Env> = async (event, env) => {
+  switch (event.cron) {
+    case "0 * * * *":
+      await runOrphanSweep(env.DB);
+      break;
+    case "0 2 * * *":
+      await runCalibrationRoll(env.DB);
+      break;
+  }
+};

--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/wrangler/config-schema.json",
   "name": "rafters-studio-web",
+  "main": "src/worker-entry.ts",
   "compatibility_date": "2026-03-18",
   "compatibility_flags": ["nodejs_compat"],
   "observability": {
@@ -31,6 +32,9 @@
       "id": "69119b2141ee4755b75a5e34364d1a2f",
     },
   ],
+  "triggers": {
+    "crons": ["0 * * * *", "0 2 * * *"],
+  },
   // FROM_EMAIL and RESEND_API_KEY: add when wiring real OTP delivery
   "r2_buckets": [
     {

--- a/tests/api/cron/calibration-roll.test.ts
+++ b/tests/api/cron/calibration-roll.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { computeBuckets } from "../../../apps/web/src/api/cron/calibration-roll";
+
+describe("computeBuckets", () => {
+  it("returns empty array when no predictions", () => {
+    expect(computeBuckets([])).toEqual([]);
+  });
+
+  it("places predictions in correct buckets", () => {
+    const predictions = [
+      { claimedConfidence: 0.75, outcomeCorrectness: 1.0 },
+      { claimedConfidence: 0.78, outcomeCorrectness: 0.0 },
+    ];
+    const rows = computeBuckets(predictions);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].bucketLower).toBe(0.7);
+    expect(rows[0].bucketUpper).toBe(0.8);
+    expect(rows[0].predictionCount).toBe(2);
+  });
+
+  it("computes correct Brier score for perfect predictions", () => {
+    const predictions = [
+      { claimedConfidence: 0.8, outcomeCorrectness: 0.8 },
+      { claimedConfidence: 0.85, outcomeCorrectness: 0.85 },
+    ];
+    const rows = computeBuckets(predictions);
+    expect(rows[0].brierScore).toBe(0);
+  });
+
+  it("computes correct Brier score for worst-case predictions", () => {
+    const predictions = [{ claimedConfidence: 0.8, outcomeCorrectness: 0.0 }];
+    const rows = computeBuckets(predictions);
+    expect(rows[0].brierScore).toBeCloseTo(0.64);
+  });
+
+  it("splits predictions across multiple buckets", () => {
+    const predictions = [
+      { claimedConfidence: 0.15, outcomeCorrectness: 1.0 },
+      { claimedConfidence: 0.85, outcomeCorrectness: 0.0 },
+    ];
+    const rows = computeBuckets(predictions);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].bucketLower).toBe(0.1);
+    expect(rows[1].bucketLower).toBe(0.8);
+  });
+
+  it("treats null outcomeCorrectness as 0", () => {
+    const predictions = [{ claimedConfidence: 0.5, outcomeCorrectness: null }];
+    const rows = computeBuckets(predictions);
+    expect(rows[0].actualCorrectness).toBe(0);
+    expect(rows[0].brierScore).toBeCloseTo(0.25);
+  });
+
+  it("excludes empty buckets from output", () => {
+    const predictions = [{ claimedConfidence: 0.55, outcomeCorrectness: 0.5 }];
+    const rows = computeBuckets(predictions);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].bucketLower).toBe(0.5);
+  });
+
+  it("computes claimedConfidence mean per bucket", () => {
+    const predictions = [
+      { claimedConfidence: 0.71, outcomeCorrectness: 1.0 },
+      { claimedConfidence: 0.79, outcomeCorrectness: 1.0 },
+    ];
+    const rows = computeBuckets(predictions);
+    expect(rows[0].claimedConfidence).toBeCloseTo(0.75);
+  });
+});

--- a/tests/api/routes/uncertainty.test.ts
+++ b/tests/api/routes/uncertainty.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { emitSchema, witnessSchema } from "../../../apps/web/src/api/routes/uncertainty";
+
+describe("emitSchema", () => {
+  const valid = {
+    surface: "rafters.color",
+    feature_key: "oklch.lowChromaHighLightness",
+    input_fingerprint: "abc123",
+    model: "claude-sonnet-4-6",
+    model_version: "2026-04-01",
+    claimed_confidence: 0.82,
+    prediction_payload: { name: "parchment" },
+  };
+
+  it("accepts valid emit payload", () => {
+    expect(emitSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("defaults orphan_ttl_days to 30", () => {
+    const result = emitSchema.safeParse(valid);
+    expect(result.success && result.data.orphan_ttl_days).toBe(30);
+  });
+
+  it("rejects claimed_confidence above 1", () => {
+    expect(emitSchema.safeParse({ ...valid, claimed_confidence: 1.1 }).success).toBe(false);
+  });
+
+  it("rejects claimed_confidence below 0", () => {
+    expect(emitSchema.safeParse({ ...valid, claimed_confidence: -0.1 }).success).toBe(false);
+  });
+
+  it("rejects empty surface", () => {
+    expect(emitSchema.safeParse({ ...valid, surface: "" }).success).toBe(false);
+  });
+
+  it("rejects missing model", () => {
+    const { model: _model, ...rest } = valid;
+    expect(emitSchema.safeParse(rest).success).toBe(false);
+  });
+});
+
+describe("witnessSchema", () => {
+  const valid = {
+    outcome_label: "accepted" as const,
+    outcome_correctness: 1.0,
+  };
+
+  it("accepts valid witness payload", () => {
+    expect(witnessSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects unknown outcome_label", () => {
+    expect(witnessSchema.safeParse({ ...valid, outcome_label: "skipped" }).success).toBe(false);
+  });
+
+  it("rejects outcome_correctness above 1", () => {
+    expect(witnessSchema.safeParse({ ...valid, outcome_correctness: 1.1 }).success).toBe(false);
+  });
+
+  it("accepts optional outcome_payload", () => {
+    const result = witnessSchema.safeParse({ ...valid, outcome_payload: { final_name: "bone" } });
+    expect(result.success).toBe(true);
+  });
+
+  it("accepts all valid outcome labels", () => {
+    const labels = ["accepted", "rejected", "edited", "ignored", "custom"] as const;
+    for (const label of labels) {
+      expect(witnessSchema.safeParse({ ...valid, outcome_label: label }).success).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- POST/PUT/GET `/api/uncertainty/*` Hono routes: emit, witness, calibration, orphans
- Orphan sweep cron (hourly) and calibration roll cron (nightly at 2am UTC)
- `computeBuckets` extracted as pure function -- Brier math testable without D1
- Worker entry point (`src/worker-entry.ts`) wires `scheduled` export alongside Astro fetch handler
- Wrangler cron triggers configured in `wrangler.jsonc`
- `/uncertainty` debug page in ctrl: surface/model filter, tabular calibration view, TanStack Query
- 19 unit tests covering Brier math, bucket placement, and schema validation

Closes #99, #100, #101, #103. #102 (rafters integration) is a cross-repo coordination issue -- posting to rafters bullpen separately.

## Test plan

- [ ] `pnpm test` passes (19 tests)
- [ ] `pnpm typecheck` clean
- [ ] Deploy and hit `POST /api/uncertainty/predictions` with a valid payload
- [ ] Confirm `GET /api/uncertainty/calibration` returns empty array before any witnessed predictions
- [ ] `/ctrl/uncertainty` page loads and renders the empty state correctly