### PR TITLE
chore: unpin claude model in .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,0 @@
-{ "model": "claude-sonnet-4-6", "effortLevel": "medium" }


### PR DESCRIPTION
## Summary
- Removes the project-local pin to claude-sonnet-4-6 (and effortLevel: medium) in .claude/settings.json.
- Sessions inherit the user default model/effort instead of being forced to Sonnet 4.6.

## Why
The pin was bundled into the Bröcker-decomposition docs commit by accident. Splitting it out so the model-policy change has its own PR and audit trail.

## Test plan
- [ ] Open a fresh Claude Code session in this repo and confirm it uses the user default rather than Sonnet 4.6.