### PR TITLE
chore(claude): trim architecture claims from project CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,31 +2,20 @@
 
 Infrastructure for all Rafters surfaces. Auth, database, API, middleware.
 
-## Apps
+## Bootstrap conventions
 
-| App      | Path         | What                                              |
-| -------- | ------------ | ------------------------------------------------- |
-| **web**  | `apps/web/`  | Cloudflare Worker -- Hono API, better-auth, D1    |
-| **ctrl** | `apps/ctrl/` | Internal operations SPA -- Vite + TanStack Router |
-
-## Stack
+Architecture decisions, app shapes, and consumer contracts live in legion reflections. Recall before grep. This file only covers invariants that the next agent must know before touching anything.
 
 - **Runtime**: Cloudflare Workers
-- **API**: Hono + `@hono/zod-validator`. Plain RPC, `AppType` exported for `hono/client`.
-- **Auth**: better-auth (native D1, passkeys + OAuth2). No email/password. Ever.
+- **API framework**: Hono + `@hono/zod-validator`
+- **Auth library**: better-auth (passkeys + OAuth2 + OTP). No email/password. Ever.
 - **Database**: Cloudflare D1, Drizzle as query builder only
 - **Schemas**: Zod is source of truth. `drizzle-zod` bridges DB to API schemas.
 - **Audit/Soft-delete/GDPR**: `@rafters/ledger`
-- **Client**: `hono/client` with `AppType` for end-to-end type safety
-- **State**: TanStack Query (cache/fetch), TanStack Forms (validation/submission)
-- **Router**: TanStack Router (ctrl SPA, file-based, type-safe)
-- **UI**: Rafters design system for all surfaces
 - **Lint/Format**: OXC (oxlint + oxc-format)
 - **TypeScript**: v6 (Go parser)
 - **Package Manager**: pnpm (never npm/yarn)
 - **IDs**: UUIDv7 for all identifiers
-
-No OpenAPI. The API is internal-only, ctrl is the only consumer. Removed in PR #92.
 
 ## Migrations
 


### PR DESCRIPTION
## Summary

Project CLAUDE.md was carrying architecture claims (`hono/client` + `AppType`, ctrl as a Vite + TanStack Router SPA, TanStack Query/Forms, OpenAPI postscript) that belong in legion reflections, not in the .md file. Global rule is recall-before-grep -- project .md should only carry bootstrap invariants the next agent must know before touching anything.

## What's removed

- **Apps table** -- ctrl row was stale. ctrl is being rebuilt as an Astro 6 app using `@rafters/astro-data`.
- **API row's "Plain RPC, AppType exported for hono/client"** -- platform delivers HTTP surface only (auth, webhooks, email, intelligence APIs). ctrl reads shared D1/R2 via its own bindings; never HTTP-calls platform.
- **Client row** (hono/client + AppType).
- **State + Router rows** (TanStack stack -- ctrl-side framework choices, not platform invariants).
- **UI row** (vague design-system pointer).
- **OpenAPI postscript** -- the decision lives in PR #92 and reflections, not restated in .md.

## What's kept

Runtime, API framework, auth library, DB, schema source of truth, audit plugin, lint, TS, pnpm, UUIDv7. Plus a new line up top pointing the next agent at reflections for architecture decisions.

Migration/schema/testing/code conventions sections below untouched -- those are real bootstrap rules.

## Reflection

`019e2d27` -- apps/web HTTP surface + ctrl-as-Astro architecture (the authoritative version of what the trimmed lines claimed).

## Test plan

- [x] No code changes; lint/format/typecheck/test green via pre-commit hooks
- [x] Reflection 019e2d27 covers what was removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)